### PR TITLE
Add custom path of cgroup file

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -36,6 +36,16 @@ func StaticPath(path string) Path {
 	}
 }
 
+// CustomPath will return the correct cgroup paths for wathever existing process running inside a cgroup
+// You can read cgroup of qemu virtual-machine with this function
+func CustomPath(path string) Path {
+	paths, err := parseCgroupFile(path)
+	if err != nil {
+		return errorPath(errors.Wrapf(err, "parse cgroup file %s", p))
+	}
+	return existingPath(paths, "")
+}
+
 // NestedPath will nest the cgroups based on the calling processes cgroup
 // placing its child processes inside its own path
 func NestedPath(suffix string) Path {

--- a/paths.go
+++ b/paths.go
@@ -41,7 +41,7 @@ func StaticPath(path string) Path {
 func CustomPath(path string) Path {
 	paths, err := parseCgroupFile(path)
 	if err != nil {
-		return errorPath(errors.Wrapf(err, "parse cgroup file %s", p))
+		return errorPath(errors.Wrapf(err, "parse cgroup file %s", path))
 	}
 	return existingPath(paths, "")
 }


### PR DESCRIPTION
Parse cgroup file in custom directory.

I want to read cgroup file of my qemu virtual-machine stored in `/opt/vms/{vm_id}/procfs/cgroup`